### PR TITLE
Mark classes final while still allow mocking

### DIFF
--- a/src/CachedDqlConditionGenerator.php
+++ b/src/CachedDqlConditionGenerator.php
@@ -31,8 +31,10 @@ use Rollerworks\Component\Search\Exception\BadMethodCallException;
  * should purge all cached entries.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @final
  */
-final class CachedDqlConditionGenerator extends AbstractCachedConditionGenerator
+class CachedDqlConditionGenerator extends AbstractCachedConditionGenerator
 {
     use QueryPlatformTrait;
 

--- a/src/CachedNativeQueryConditionGenerator.php
+++ b/src/CachedNativeQueryConditionGenerator.php
@@ -29,8 +29,10 @@ use Psr\SimpleCache\CacheInterface as Cache;
  * should purge all cached entries.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @final
  */
-final class CachedNativeQueryConditionGenerator extends AbstractCachedConditionGenerator
+class CachedNativeQueryConditionGenerator extends AbstractCachedConditionGenerator
 {
     /**
      * @var NativeQuery

--- a/src/DoctrineOrmFactory.php
+++ b/src/DoctrineOrmFactory.php
@@ -20,8 +20,10 @@ use Rollerworks\Component\Search\SearchCondition;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @final
  */
-final class DoctrineOrmFactory
+class DoctrineOrmFactory
 {
     /**
      * @var Cache

--- a/src/DqlConditionGenerator.php
+++ b/src/DqlConditionGenerator.php
@@ -38,6 +38,8 @@ use Rollerworks\Component\Search\SearchCondition;
  *  * Conversions require the correct query-hint to be set.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @final
  */
 final class DqlConditionGenerator extends AbstractConditionGenerator
 {

--- a/src/NativeQueryConditionGenerator.php
+++ b/src/NativeQueryConditionGenerator.php
@@ -34,8 +34,10 @@ use Rollerworks\Component\Search\SearchCondition;
  *  * Conversion results must be properly escaped to prevent SQL injections.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @final
  */
-final class NativeQueryConditionGenerator extends AbstractConditionGenerator
+class NativeQueryConditionGenerator extends AbstractConditionGenerator
 {
     private $query;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Use `@final` instead making a class final, else mocking this in the API-Platform bridge is impossible and overcomplicates testing logic.